### PR TITLE
fix: :bug: Having `generate_backup.sh` not require an argument as it must be used as a cronjob

### DIFF
--- a/game-servers/terraria/server/start-server.sh
+++ b/game-servers/terraria/server/start-server.sh
@@ -21,7 +21,7 @@ download_backup() {
     echo "Backup downloaded successfully."
   else
     echo "Backup for $save_name does not exist in GCS. Generating first-time backup."
-    /etc/terraria/generate_backup.sh "$save_name"
+    /etc/terraria/generate_backup.sh
   fi
 }
 


### PR DESCRIPTION
Mimicking code in `start-server.sh` in order to resolve the save name being backed up from a temporary config file, or the instance's custom metadata. Removing argument input when calling `generate_backup.sh` in `download_backup()`