### PR TITLE
fix: :bug: resolve backup cronjob failure

### DIFF
--- a/game-servers/minecraft/scripts/crontab-setup.sh
+++ b/game-servers/minecraft/scripts/crontab-setup.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-(crontab -l 2>/dev/null; echo "0 * * * * /etc/minecraft/generate_backup.sh") | crontab -
+(crontab -l 2>/dev/null; echo "0 * * * * /etc/minecraft/generate_backup.sh") | sudo crontab -

--- a/game-servers/terraria/scripts/crontab-setup.sh
+++ b/game-servers/terraria/scripts/crontab-setup.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-(crontab -l 2>/dev/null; echo "0 * * * * /etc/terraria/generate_backup.sh") | crontab -
+(crontab -l 2>/dev/null; echo "0 * * * * /etc/terraria/generate_backup.sh") | sudo crontab -


### PR DESCRIPTION
Logs indicate that the 'packer' user has been executing the generate_backup.sh script on instances. This is due to the packer pipeline not executing the crontab command as root, or any other user that has access to the necessary files/folders to backup.

This change adds the sudo directive to crontab ensuring that the cronjob is executed as root.